### PR TITLE
Bug fix: button overflow for community item on mobile

### DIFF
--- a/src/components/Community/CommunityItem.tsx
+++ b/src/components/Community/CommunityItem.tsx
@@ -18,6 +18,9 @@ interface CommunityItemProps {
 
 /**
  * Card displaying a community (name and logo) with the subscribe button and the number of members.
+ * The card is clickable and will redirect to the community page.
+ * If the screen size is mobile, the name and logo will be on top of the subscribe button and the number of members.
+ * If the screen size is desktop, the name and logo will be on the left side of the card and the subscribe button and the number of members will be on the right side.
  * @param {Community} community - community object
  * @param {boolean} isJoined - whether the user is joined to the community
  * @param {(community: Community, isJoined: boolean) => void} onJoinOrLeaveCommunity - function to join or leave a community
@@ -50,54 +53,112 @@ const CommunityItem: React.FC<CommunityItemProps> = ({
       }}
       shadow="md"
     >
-      <Flex width="80%" align="center">
-        <Flex align="center">
-          {community.imageURL ? (
-            <Image
-              src={community.imageURL}
-              borderRadius="full"
-              boxSize="35px"
-              mr={4}
-              alt="Community Icon"
-            />
-          ) : (
-            <Icon
-              as={IoPeopleCircleOutline}
-              fontSize={38}
-              color="red.500"
-              mr={4}
-            />
-          )}
-          <Text fontSize={16}>{community.id}</Text>
-        </Flex>
-      </Flex>
-      <Stack direction="row" align="center">
-        <Flex
-          fontSize={18}
-          color="gray.500"
-          justify="center"
-          align="center"
-          mr={2}
-        >
-          <Icon as={BsFillPeopleFill} mr={1} />
-          {community.numberOfMembers}
-        </Flex>
-        <Button
-          height="30px"
-          width="130px"
-          fontSize="10pt"
-          variant={isJoined ? "outline" : "solid"}
-          onClick={(event) => {
-            event.preventDefault();
-            event.stopPropagation(); // stop the event from bubbling up
-            onJoinOrLeaveCommunity(community, isJoined);
-          }}
-        >
-          {isJoined ? "Unsubscribe" : "Subscribe"}
-        </Button>
+      <Stack
+        direction={{ base: "column", md: "row" }}
+        flexGrow={1}
+        align="left"
+      >
+        <CommunityItemNameIconSection community={community} />
+        <CommunityItemButtonMembersSection
+          community={community}
+          onJoinOrLeaveCommunity={onJoinOrLeaveCommunity}
+          isJoined={isJoined}
+        />
       </Stack>
     </Flex>
   );
 };
 
 export default CommunityItem;
+
+/**
+ * @param {Community} community - community object
+ */
+type CommunityItemNameIconSectionProps = {
+  community: Community;
+};
+
+/**
+ * Displays the community name and icon on top of the community item card.
+ * @param {Community} community - community object
+ * @returns {React.FC} - the community item name and icon section component
+ */
+const CommunityItemNameIconSection = ({
+  community,
+}: CommunityItemNameIconSectionProps) => {
+  return (
+    <Flex align="center" width="100%">
+      <Flex align="center" direction="row">
+        {community.imageURL ? (
+          <Image
+            src={community.imageURL}
+            borderRadius="full"
+            boxSize="35px"
+            mr={4}
+            alt="Community Icon"
+          />
+        ) : (
+          <Icon
+            as={IoPeopleCircleOutline}
+            fontSize={38}
+            color="red.500"
+            mr={4}
+          />
+        )}
+        <Text fontSize={16}>{community.id}</Text>
+      </Flex>
+    </Flex>
+  );
+};
+
+/**
+ * @param {Community} community - community object
+ * @param {boolean} isJoined - whether the user is joined to the community
+ * @param {(community: Community, isJoined: boolean) => void} onJoinOrLeaveCommunity - function to join or leave a community
+ */
+type CommunityItemButtonMembersSectionProps = {
+  community: Community;
+  onJoinOrLeaveCommunity: (community: Community, isJoined: boolean) => void;
+  isJoined: boolean;
+};
+
+/**
+ * Displays the subscribe button and the number of members on the bottom of the community item card.
+ * @param {Community} community - community object
+ * @param {boolean} isJoined - whether the user is joined to the community
+ * @param {(community: Community, isJoined: boolean) => void} onJoinOrLeaveCommunity - function to join or leave a community
+ * @returns {React.FC} - the community item button and members section component
+ */
+const CommunityItemButtonMembersSection = ({
+  community,
+  onJoinOrLeaveCommunity,
+  isJoined,
+}: CommunityItemButtonMembersSectionProps) => {
+  return (
+    <Stack direction="row" align="center" justifyContent="space-between">
+      <Flex
+        fontSize={18}
+        color="gray.500"
+        justify="center"
+        align="center"
+        mr={2}
+      >
+        <Icon as={BsFillPeopleFill} mr={1} />
+        {community.numberOfMembers}
+      </Flex>
+      <Button
+        height="30px"
+        width="130px"
+        fontSize="10pt"
+        variant={isJoined ? "outline" : "solid"}
+        onClick={(event) => {
+          event.preventDefault();
+          event.stopPropagation(); // stop the event from bubbling up
+          onJoinOrLeaveCommunity(community, isJoined);
+        }}
+      >
+        {isJoined ? "Unsubscribe" : "Subscribe"}
+      </Button>
+    </Stack>
+  );
+};


### PR DESCRIPTION
- #68 Button and subscriber number would flow outside the community item card on mobile devices if the name of the community is too long
- Now, if the screen is mobile, the button and member numbers would be stacked bellow the name and icon section
- The functionality for larger screen is still the same as before